### PR TITLE
feat(gateway-api): Add custom backendRef and filters support for HTTPRoute - Unit Tests

### DIFF
--- a/codebeaver.yml
+++ b/codebeaver.yml
@@ -1,0 +1,2 @@
+from:go-1.23
+# This file was generated automatically by CodeBeaver based on your repository. Learn how to customize it here: https://docs.codebeaver.ai/configuration/

--- a/pkg/apis/flagger/v1beta1/canary_test.go
+++ b/pkg/apis/flagger/v1beta1/canary_test.go
@@ -1,0 +1,451 @@
+package v1beta1
+
+import (
+    "testing"
+    "time"
+    gwv1beta1 "github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1beta1"
+)
+
+// TestHTTPRewriteGetType tests the GetType method of HTTPRewrite.
+func TestHTTPRewriteGetType(t *testing.T) {
+    // When Type matches the constant for prefix, it should return that constant.
+    rw := &HTTPRewrite{Type: string(gwv1beta1.PrefixMatchHTTPPathModifier)}
+    if rw.GetType() != string(gwv1beta1.PrefixMatchHTTPPathModifier) {
+        t.Errorf("Expected type '%s', got %s", string(gwv1beta1.PrefixMatchHTTPPathModifier), rw.GetType())
+    }
+
+    // When Type is empty, GetType should return the default full path modifier.
+    rw.Type = ""
+    if rw.GetType() != string(gwv1beta1.FullPathHTTPPathModifier) {
+        t.Errorf("Expected type '%s', got %s", string(gwv1beta1.FullPathHTTPPathModifier), rw.GetType())
+    }
+
+}
+
+// TestCanaryServiceGetIstioRewrite tests the GetIstioRewrite method of CanaryService.
+func TestCanaryServiceGetIstioRewrite(t *testing.T) {
+    cs := &CanaryService{}
+    // With nil Rewrite, the method should return nil.
+    if cs.GetIstioRewrite() != nil {
+    t.Error("Expected nil IstioRewrite when Rewrite is nil")
+    }
+
+    // With a proper Rewrite, the method should return an istio rewrite object.
+    cs.Rewrite = &HTTPRewrite{
+    Authority: "example.com",
+    Uri:       "/test",
+    }
+    istioRewrite := cs.GetIstioRewrite()
+    if istioRewrite == nil {
+    t.Error("Expected valid IstioRewrite object")
+    }
+    if istioRewrite.Authority != "example.com" || istioRewrite.Uri != "/test" {
+    t.Errorf("IstioRewrite mismatch: got %+v", istioRewrite)
+    }
+}
+
+// TestSessionAffinityGetMaxAge tests the GetMaxAge method of SessionAffinity.
+func TestSessionAffinityGetMaxAge(t *testing.T) {
+    sa := &SessionAffinity{}
+    // Expect the default value of 86400 seconds if MaxAge is 0.
+    if sa.GetMaxAge() != 86400 {
+    t.Errorf("Expected default max age 86400, got %d", sa.GetMaxAge())
+    }
+    sa.MaxAge = 100
+    if sa.GetMaxAge() != 100 {
+    t.Errorf("Expected max age 100, got %d", sa.GetMaxAge())
+    }
+}
+
+// TestGetServiceNames tests the GetServiceNames method of Canary.
+func TestGetServiceNames(t *testing.T) {
+    c := &Canary{
+    Spec: CanarySpec{
+    TargetRef: LocalObjectReference{
+    Name: "myapp",
+    },
+    Service: CanaryService{
+    Name: "custom-service",
+    },
+    },
+    }
+    apex, primary, canarySvc := c.GetServiceNames()
+    if apex != "custom-service" {
+    t.Errorf("Expected apex name 'custom-service', got %s", apex)
+    }
+    if primary != "custom-service-primary" {
+    t.Errorf("Expected primary name 'custom-service-primary', got %s", primary)
+    }
+    if canarySvc != "custom-service-canary" {
+    t.Errorf("Expected canary name 'custom-service-canary', got %s", canarySvc)
+    }
+}
+
+// TestProgressDeadline tests the GetProgressDeadlineSeconds method of Canary.
+func TestProgressDeadline(t *testing.T) {
+    // Test default deadline.
+    c := &Canary{
+    Spec: CanarySpec{},
+    }
+    if c.GetProgressDeadlineSeconds() != ProgressDeadlineSeconds {
+    t.Errorf("Expected default progress deadline %d, got %d", ProgressDeadlineSeconds, c.GetProgressDeadlineSeconds())
+    }
+    // Test a custom deadline.
+    deadline := int32(300)
+    c.Spec.ProgressDeadlineSeconds = &deadline
+    if c.GetProgressDeadlineSeconds() != 300 {
+    t.Errorf("Expected custom progress deadline 300, got %d", c.GetProgressDeadlineSeconds())
+    }
+}
+
+// TestGetAnalysis tests the GetAnalysis method of Canary.
+func TestGetAnalysis(t *testing.T) {
+    c := &Canary{
+    Spec: CanarySpec{
+    Analysis: &CanaryAnalysis{Interval: "30s"},
+    },
+    }
+    analysis := c.GetAnalysis()
+    if analysis == nil || analysis.Interval != "30s" {
+    t.Errorf("Expected analysis interval '30s', got %+v", analysis)
+    }
+
+    // When Analysis is nil, but CanaryAnalysis is provided.
+    c.Spec.Analysis = nil
+    c.Spec.CanaryAnalysis = &CanaryAnalysis{Interval: "45s"}
+    analysis = c.GetAnalysis()
+    if analysis == nil || analysis.Interval != "45s" {
+    t.Errorf("Expected canaryAnalysis interval '45s', got %+v", analysis)
+    }
+}
+
+// TestGetAnalysisInterval tests the GetAnalysisInterval method of Canary.
+func TestGetAnalysisInterval(t *testing.T) {
+    c := &Canary{
+    Spec: CanarySpec{
+    Analysis: &CanaryAnalysis{Interval: "15s"},
+    },
+    }
+    if c.GetAnalysisInterval() != 15*time.Second {
+    t.Errorf("Expected analysis interval 15s, got %v", c.GetAnalysisInterval())
+    }
+
+    // Test with an invalid duration: should fall back to default.
+    c.Spec.Analysis.Interval = "invalid"
+    if c.GetAnalysisInterval() != AnalysisInterval {
+    t.Errorf("Expected fallback analysis interval %v, got %v", AnalysisInterval, c.GetAnalysisInterval())
+    }
+
+    // Test enforcing a minimum duration (if less than 10s, return 10s).
+    c.Spec.Analysis.Interval = "5s"
+    if c.GetAnalysisInterval() != 10*time.Second {
+    t.Errorf("Expected enforced minimum analysis interval 10s, got %v", c.GetAnalysisInterval())
+    }
+}
+
+// TestGetAnalysisThreshold tests the GetAnalysisThreshold method of Canary.
+func TestGetAnalysisThreshold(t *testing.T) {
+    c := &Canary{
+    Spec: CanarySpec{
+    Analysis: &CanaryAnalysis{Threshold: 3},
+    },
+    }
+    if c.GetAnalysisThreshold() != 3 {
+    t.Errorf("Expected analysis threshold 3, got %d", c.GetAnalysisThreshold())
+    }
+
+    // With threshold 0, the default value (1) should be returned.
+    c.Spec.Analysis.Threshold = 0
+    if c.GetAnalysisThreshold() != 1 {
+    t.Errorf("Expected analysis threshold default 1, got %d", c.GetAnalysisThreshold())
+    }
+}
+
+// TestReadyThresholds tests GetAnalysisPrimaryReadyThreshold and GetAnalysisCanaryReadyThreshold.
+func TestReadyThresholds(t *testing.T) {
+    // Test defaults when ready thresholds are not set.
+    c := &Canary{
+    Spec: CanarySpec{
+    Analysis: &CanaryAnalysis{},
+    },
+    }
+    if c.GetAnalysisPrimaryReadyThreshold() != PrimaryReadyThreshold {
+    t.Errorf("Expected primary ready threshold %d, got %d", PrimaryReadyThreshold, c.GetAnalysisPrimaryReadyThreshold())
+    }
+    if c.GetAnalysisCanaryReadyThreshold() != CanaryReadyThreshold {
+    t.Errorf("Expected canary ready threshold %d, got %d", CanaryReadyThreshold, c.GetAnalysisCanaryReadyThreshold())
+    }
+
+    // Test custom ready threshold values.
+    customThreshold := 80
+    c.Spec.Analysis.PrimaryReadyThreshold = &customThreshold
+    c.Spec.Analysis.CanaryReadyThreshold = &customThreshold
+    if c.GetAnalysisPrimaryReadyThreshold() != 80 {
+        t.Errorf("Expected primary ready threshold 80, got %d", c.GetAnalysisPrimaryReadyThreshold())
+    }
+    if c.GetAnalysisCanaryReadyThreshold() != 80 {
+        t.Errorf("Expected canary ready threshold 80, got %d", c.GetAnalysisCanaryReadyThreshold())
+    }
+    c.Spec.Analysis.PrimaryReadyThreshold = &customThreshold
+    c.Spec.Analysis.CanaryReadyThreshold = &customThreshold
+    if c.GetAnalysisCanaryReadyThreshold() != 80 {
+    t.Errorf("Expected canary ready threshold 80, got %d", c.GetAnalysisCanaryReadyThreshold())
+    }
+}
+
+// TestGetMetricInterval tests that GetMetricInterval returns the default metric interval.
+func TestGetMetricInterval(t *testing.T) {
+    c := &Canary{}
+    if c.GetMetricInterval() != MetricInterval {
+    t.Errorf("Expected metric interval %s, got %s", MetricInterval, c.GetMetricInterval())
+    }
+}
+
+// TestSkipAnalysis tests the SkipAnalysis method of Canary.
+func TestSkipAnalysis(t *testing.T) {
+    // When both Analysis and CanaryAnalysis are nil, SkipAnalysis should return true.
+    c := &Canary{
+    Spec: CanarySpec{
+    Analysis:       nil,
+    CanaryAnalysis: nil,
+    SkipAnalysis:   false,
+    },
+    }
+    if !c.SkipAnalysis() {
+    t.Error("Expected SkipAnalysis to return true when analysis fields are nil")
+    }
+
+    // When an analysis is present, the SkipAnalysis flag should be effective.
+    c.Spec.Analysis = &CanaryAnalysis{}
+    c.Spec.SkipAnalysis = true
+    if !c.SkipAnalysis() {
+    t.Errorf("Expected SkipAnalysis to return true when SkipAnalysis flag is true")
+    }
+    c.Spec.SkipAnalysis = false
+    if c.SkipAnalysis() {
+    t.Errorf("Expected SkipAnalysis to return false when analysis is present and flag is false")
+    }
+}
+// TestHTTPRewriteGetType_NonPrefix tests that if HTTPRewrite type is not the prefix match,
+func TestHTTPRewriteGetType_NonPrefix(t *testing.T) {
+    rw := &HTTPRewrite{Type: "custom"}
+    expected := string(gwv1beta1.FullPathHTTPPathModifier)
+    if got := rw.GetType(); got != expected {
+        t.Errorf("Expected type '%s', got '%s'", expected, got)
+    }
+}
+
+// TestGetAnalysisNil tests that GetAnalysis returns nil when both Analysis and CanaryAnalysis are nil.
+func TestGetAnalysisNil(t *testing.T) {
+    c := &Canary{
+        Spec: CanarySpec{},
+    }
+    if analysis := c.GetAnalysis(); analysis != nil {
+        t.Errorf("Expected nil analysis when both Analysis and CanaryAnalysis are nil, got %+v", analysis)
+    }
+}
+
+// TestGetAnalysis_BothSet tests that when both Analysis and CanaryAnalysis are provided,
+func TestGetAnalysis_BothSet(t *testing.T) {
+    c := &Canary{
+        Spec: CanarySpec{
+            Analysis:       &CanaryAnalysis{Interval: "20s"},
+            CanaryAnalysis: &CanaryAnalysis{Interval: "40s"},
+        },
+    }
+    analysis := c.GetAnalysis()
+    if analysis == nil || analysis.Interval != "20s" {
+        t.Errorf("Expected analysis interval '20s', got %+v", analysis)
+    }
+}
+
+// TestGetAnalysisInterval_NoAnalysis tests that GetAnalysisInterval panics when no Analysis (or CanaryAnalysis) is set.
+func TestGetAnalysisInterval_NoAnalysis(t *testing.T) {
+    c := &Canary{
+        Spec: CanarySpec{},
+    }
+    defer func() {
+        if r := recover(); r == nil {
+            t.Error("Expected panic when GetAnalysisInterval is called with nil analysis")
+        }
+    }()
+    _ = c.GetAnalysisInterval()
+}
+// TestGetServiceNames_Default tests that when Service.Name is empty, the apex name falls back to TargetRef.Name.
+func TestGetServiceNames_Default(t *testing.T) {
+    c := &Canary{
+        Spec: CanarySpec{
+            TargetRef: LocalObjectReference{Name: "app-default"},
+            Service: CanaryService{
+                Port: 80,
+            },
+        },
+    }
+    apex, primary, canarySvc := c.GetServiceNames()
+    if apex != "app-default" {
+        t.Errorf("Expected apex name 'app-default', got %s", apex)
+    }
+    if primary != "app-default-primary" {
+        t.Errorf("Expected primary name 'app-default-primary', got %s", primary)
+    }
+    if canarySvc != "app-default-canary" {
+        t.Errorf("Expected canary name 'app-default-canary', got %s", canarySvc)
+    }
+}
+
+// TestCanaryServiceGetIstioRewrite_Empty tests that GetIstioRewrite returns an object (even with empty Rewrite values).
+func TestCanaryServiceGetIstioRewrite_Empty(t *testing.T) {
+    cs := &CanaryService{
+        Rewrite: &HTTPRewrite{},
+    }
+    istioRewrite := cs.GetIstioRewrite()
+    if istioRewrite == nil {
+        t.Error("Expected IstioRewrite object, got nil")
+    }
+    if istioRewrite.Authority != "" || istioRewrite.Uri != "" {
+        t.Errorf("Expected empty IstioRewrite fields, got %+v", istioRewrite)
+    }
+}
+
+// TestGetAnalysisInterval_MinimumEnforcement tests that extremely short intervals (e.g., "1s") are bumped to the minimum (10s).
+func TestGetAnalysisInterval_MinimumEnforcement(t *testing.T) {
+    c := &Canary{
+        Spec: CanarySpec{
+            Analysis: &CanaryAnalysis{Interval: "1s"},
+        },
+    }
+    interval := c.GetAnalysisInterval()
+    if interval != 10*time.Second {
+        t.Errorf("Expected enforced minimum analysis interval 10s, got %v", interval)
+    }
+}
+
+// TestFullCanaryGetterDefaults tests a fully default Canary configuration and verifies the getters return expected default values.
+func TestFullCanaryGetterDefaults(t *testing.T) {
+    deadline := int32(400)
+    analysis := &CanaryAnalysis{
+        // Threshold not set, should default to 1 in getter.
+    }
+
+    c := &Canary{
+        Spec: CanarySpec{
+            TargetRef: LocalObjectReference{Name: "default-app"},
+            Service: CanaryService{
+                Port: 8080,
+            },
+            Analysis: analysis,
+            ProgressDeadlineSeconds: &deadline,
+            SkipAnalysis: false,
+        },
+    }
+
+    // Check GetServiceNames
+    apex, primary, canarySvc := c.GetServiceNames()
+    if apex != "default-app" {
+        t.Errorf("Expected apex name 'default-app', got %s", apex)
+    }
+    if primary != "default-app-primary" {
+        t.Errorf("Expected primary name 'default-app-primary', got %s", primary)
+    }
+    if canarySvc != "default-app-canary" {
+        t.Errorf("Expected canary name 'default-app-canary', got %s", canarySvc)
+    }
+
+    // Check GetProgressDeadlineSeconds should return 400
+    if c.GetProgressDeadlineSeconds() != 400 {
+        t.Errorf("Expected progress deadline 400, got %d", c.GetProgressDeadlineSeconds())
+    }
+
+    // GetAnalysisInterval: Analysis.Interval is empty so should fall back to default (60s)
+    if c.GetAnalysisInterval() != AnalysisInterval {
+        t.Errorf("Expected analysis interval %v, got %v", AnalysisInterval, c.GetAnalysisInterval())
+    }
+
+    // GetAnalysisThreshold should return 1 (default) as threshold is unset
+    if c.GetAnalysisThreshold() != 1 {
+        t.Errorf("Expected analysis threshold default 1, got %d", c.GetAnalysisThreshold())
+    }
+
+    // GetAnalysisPrimaryReadyThreshold should return default PrimaryReadyThreshold (100)
+    if c.GetAnalysisPrimaryReadyThreshold() != PrimaryReadyThreshold {
+        t.Errorf("Expected primary ready threshold %d, got %d", PrimaryReadyThreshold, c.GetAnalysisPrimaryReadyThreshold())
+    }
+
+    // GetAnalysisCanaryReadyThreshold should return default CanaryReadyThreshold (100)
+    if c.GetAnalysisCanaryReadyThreshold() != CanaryReadyThreshold {
+        t.Errorf("Expected canary ready threshold %d, got %d", CanaryReadyThreshold, c.GetAnalysisCanaryReadyThreshold())
+    }
+
+    // GetMetricInterval should return the default metric interval "1m"
+    if c.GetMetricInterval() != MetricInterval {
+        t.Errorf("Expected metric interval %s, got %s", MetricInterval, c.GetMetricInterval())
+    }
+
+    // Since Analysis is set, SkipAnalysis should return the flag (false)
+    if c.SkipAnalysis() != false {
+        t.Errorf("Expected SkipAnalysis false, got true")
+    }
+}
+// TestGetAnalysisInterval_ZeroDuration tests that when the Analysis interval is "0s", 
+// the enforced minimum duration of 10 seconds is returned.
+func TestGetAnalysisInterval_ZeroDuration(t *testing.T) {
+    c := &Canary{
+        Spec: CanarySpec{
+            Analysis: &CanaryAnalysis{Interval: "0s"},
+        },
+    }
+    expected := 10 * time.Second
+    if dur := c.GetAnalysisInterval(); dur != expected {
+        t.Errorf("Expected analysis interval %v for '0s', got %v", expected, dur)
+    }
+}
+
+// TestAutoscalerReference tests that the AutoscalerReference fields are correctly assigned.
+func TestAutoscalerReference(t *testing.T) {
+    asr := &AutoscalerRefernce{
+        APIVersion: "autoscaling/v1",
+        Kind:       "HorizontalPodAutoscaler",
+        Name:       "hpa-test",
+        PrimaryScalerQueries: map[string]string{
+            "query1": "value1",
+        },
+        PrimaryScalerReplicas: &ScalerReplicas{
+            MinReplicas: int32Ptr(1),
+            MaxReplicas: int32Ptr(10),
+        },
+    }
+
+    c := &Canary{
+        Spec: CanarySpec{
+            AutoscalerRef: asr,
+        },
+    }
+
+    if c.Spec.AutoscalerRef.APIVersion != "autoscaling/v1" {
+        t.Errorf("Expected AutoscalerRef.APIVersion 'autoscaling/v1', got %s", c.Spec.AutoscalerRef.APIVersion)
+    }
+    if c.Spec.AutoscalerRef.Kind != "HorizontalPodAutoscaler" {
+        t.Errorf("Expected AutoscalerRef.Kind 'HorizontalPodAutoscaler', got %s", c.Spec.AutoscalerRef.Kind)
+    }
+    if c.Spec.AutoscalerRef.Name != "hpa-test" {
+        t.Errorf("Expected AutoscalerRef.Name 'hpa-test', got %s", c.Spec.AutoscalerRef.Name)
+    }
+    if q, ok := c.Spec.AutoscalerRef.PrimaryScalerQueries["query1"]; !ok || q != "value1" {
+        t.Errorf("Expected PrimaryScalerQueries[\"query1\"] 'value1', got %s", q)
+    }
+    if c.Spec.AutoscalerRef.PrimaryScalerReplicas == nil {
+        t.Error("Expected PrimaryScalerReplicas to be non-nil")
+    } else {
+        if c.Spec.AutoscalerRef.PrimaryScalerReplicas.MinReplicas == nil || *c.Spec.AutoscalerRef.PrimaryScalerReplicas.MinReplicas != 1 {
+            t.Errorf("Expected MinReplicas to be 1, got %v", c.Spec.AutoscalerRef.PrimaryScalerReplicas.MinReplicas)
+        }
+        if c.Spec.AutoscalerRef.PrimaryScalerReplicas.MaxReplicas == nil || *c.Spec.AutoscalerRef.PrimaryScalerReplicas.MaxReplicas != 10 {
+            t.Errorf("Expected MaxReplicas to be 10, got %v", c.Spec.AutoscalerRef.PrimaryScalerReplicas.MaxReplicas)
+        }
+    }
+}
+
+// int32Ptr is a helper function that returns a pointer to the given int32 value.
+func int32Ptr(i int32) *int32 {
+    return &i
+}

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy_test.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy_test.go
@@ -1,0 +1,467 @@
+package v1beta1
+
+import (
+    "reflect"
+    "testing"
+    "time"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    v1 "k8s.io/api/core/v1"
+    gatewayapiv1 "github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1"
+    istiov1beta1 "github.com/fluxcd/flagger/pkg/apis/istio/v1beta1"
+)
+
+// TestDeepCopyAlertProvider tests the DeepCopy and DeepCopyObject functions for AlertProvider.
+func TestDeepCopyAlertProvider(t *testing.T) {
+    orig := &AlertProvider{
+        TypeMeta:   metav1.TypeMeta{Kind: "AlertProvider", APIVersion: "v1beta1"},
+        ObjectMeta: metav1.ObjectMeta{Name: "alert1", Namespace: "default"},
+        Spec: AlertProviderSpec{
+            SecretRef: &v1.LocalObjectReference{Name: "secret1"},
+        },
+        Status: AlertProviderStatus{
+            Conditions: []AlertProviderCondition{
+                {
+                    LastUpdateTime:     metav1.Time{Time: time.Now()},
+                    LastTransitionTime: metav1.Time{Time: time.Now()},
+                },
+            },
+        },
+    }
+
+    copyObj := orig.DeepCopy()
+    if copyObj == orig {
+        t.Errorf("DeepCopy returned the same pointer")
+    }
+
+    if !reflect.DeepEqual(orig, copyObj) {
+        t.Errorf("DeepCopy did not produce an equivalent object")
+    }
+
+    // Modify the copy and check that the original is not affected.
+    copyObj.Spec.SecretRef.Name = "changed-secret"
+    if orig.Spec.SecretRef.Name == "changed-secret" {
+        t.Errorf("DeepCopy is shallow; modification in copy affected the original")
+    }
+}
+
+// TestDeepCopyObjectAlertProvider tests the DeepCopyObject method for AlertProvider.
+func TestDeepCopyObjectAlertProvider(t *testing.T) {
+    orig := &AlertProvider{
+        TypeMeta:   metav1.TypeMeta{Kind: "AlertProvider", APIVersion: "v1beta1"},
+        ObjectMeta: metav1.ObjectMeta{Name: "alert1", Namespace: "default"},
+    }
+
+    obj := orig.DeepCopyObject()
+    castObj, ok := obj.(*AlertProvider)
+    if !ok {
+        t.Errorf("DeepCopyObject did not return an *AlertProvider")
+    }
+
+    if !reflect.DeepEqual(orig, castObj) {
+        t.Errorf("DeepCopyObject did not produce an equivalent object")
+    }
+}
+
+// TestDeepCopyCanary tests the DeepCopy and DeepCopyObject functions for Canary.
+func TestDeepCopyCanary(t *testing.T) {
+    orig := &Canary{
+        TypeMeta:   metav1.TypeMeta{Kind: "Canary", APIVersion: "v1beta1"},
+        ObjectMeta: metav1.ObjectMeta{Name: "canary1", Namespace: "default"},
+        Spec: CanarySpec{
+            IngressRef: &LocalObjectReference{Name: "ingress1"},
+            RouteRef:   &LocalObjectReference{Name: "route1"},
+            Service: CanaryService{
+                Gateways: []string{"gateway1", "gateway2"},
+                Hosts:    []string{"host1", "host2"},
+            },
+            ProgressDeadlineSeconds: new(int32),
+        },
+        Status: CanaryStatus{
+            Conditions: []CanaryCondition{
+                {
+                    LastUpdateTime:     metav1.Time{Time: time.Now()},
+                    LastTransitionTime: metav1.Time{Time: time.Now()},
+                },
+            },
+        },
+    }
+    *orig.Spec.ProgressDeadlineSeconds = 30
+
+    copyObj := orig.DeepCopy()
+    if copyObj == orig {
+        t.Errorf("DeepCopy returned the same pointer")
+    }
+
+    if !reflect.DeepEqual(orig, copyObj) {
+        t.Errorf("DeepCopy did not produce an equivalent object")
+    }
+
+    // Modify nested fields and verify the original remains unchanged.
+    copyObj.ObjectMeta.Name = "changed-canary"
+    if orig.ObjectMeta.Name == "changed-canary" {
+        t.Errorf("Modifying copy's ObjectMeta affected the original")
+    }
+}
+
+// TestDeepCopyObjectCanary tests the DeepCopyObject method for Canary.
+func TestDeepCopyObjectCanary(t *testing.T) {
+    orig := &Canary{
+        TypeMeta:   metav1.TypeMeta{Kind: "Canary", APIVersion: "v1beta1"},
+        ObjectMeta: metav1.ObjectMeta{Name: "canary1", Namespace: "default"},
+    }
+
+    obj := orig.DeepCopyObject()
+    castObj, ok := obj.(*Canary)
+    if !ok {
+        t.Errorf("DeepCopyObject did not return an *Canary")
+    }
+
+    if !reflect.DeepEqual(orig, castObj) {
+        t.Errorf("DeepCopyObject did not produce an equivalent object")
+    }
+}
+
+// TestDeepCopyCanarySpec tests the deep copy of CanarySpec including maps.
+func TestDeepCopyCanarySpec(t *testing.T) {
+    progress := int32(60)
+    orig := &CanarySpec{
+        IngressRef: &LocalObjectReference{Name: "ingress1"},
+        RouteRef:   &LocalObjectReference{Name: "route1"},
+        ProgressDeadlineSeconds: &progress,
+        AutoscalerRef: &AutoscalerRefernce{
+            PrimaryScalerQueries: map[string]string{"query": "value"},
+        },
+    }
+
+    copySpec := orig.DeepCopy()
+    if copySpec == orig {
+        t.Errorf("DeepCopy returned the same pointer for CanarySpec")
+    }
+
+    if !reflect.DeepEqual(orig, copySpec) {
+        t.Errorf("DeepCopy did not produce an equivalent CanarySpec")
+    }
+
+    // Modify the copy and ensure the original is not affected.
+    copySpec.AutoscalerRef.PrimaryScalerQueries["query"] = "modified"
+    if orig.AutoscalerRef.PrimaryScalerQueries["query"] == "modified" {
+        t.Errorf("Modifying the deep copy of CanarySpec affected the original")
+    }
+}
+
+// TestDeepCopyMetricTemplate tests the DeepCopy and DeepCopyObject functions for MetricTemplate.
+func TestDeepCopyMetricTemplate(t *testing.T) {
+    orig := &MetricTemplate{
+        TypeMeta:   metav1.TypeMeta{Kind: "MetricTemplate", APIVersion: "v1beta1"},
+        ObjectMeta: metav1.ObjectMeta{Name: "mt1", Namespace: "default"},
+        Spec: MetricTemplateSpec{
+            Provider: MetricTemplateProvider{
+                SecretRef: &v1.LocalObjectReference{Name: "secret-mt"},
+            },
+        },
+        Status: MetricTemplateStatus{
+            Conditions: []MetricTemplateCondition{
+                {
+                    LastUpdateTime:     metav1.Time{Time: time.Now()},
+                    LastTransitionTime: metav1.Time{Time: time.Now()},
+                },
+            },
+        },
+    }
+
+    copyMT := orig.DeepCopy()
+    if copyMT == orig {
+        t.Errorf("DeepCopy returned the same pointer for MetricTemplate")
+    }
+
+    if !reflect.DeepEqual(orig, copyMT) {
+        t.Errorf("DeepCopy did not produce an equivalent MetricTemplate")
+    }
+
+    // Modify the copy and verify that the original remains unchanged.
+    copyMT.Spec.Provider.SecretRef.Name = "changed-secret-mt"
+    if orig.Spec.Provider.SecretRef.Name == "changed-secret-mt" {
+        t.Errorf("Modifying the deep copy of MetricTemplate affected the original")
+    }
+}
+// TestDeepCopyNilValues tests that calling DeepCopy on nil pointers returns nil.
+func TestDeepCopyNilValues(t *testing.T) {
+    var ap *AlertProvider = nil
+    if got := ap.DeepCopy(); got != nil {
+        t.Errorf("Expected nil deep copy for AlertProvider, got %v", got)
+    }
+
+    var c *Canary = nil
+    if got := c.DeepCopy(); got != nil {
+        t.Errorf("Expected nil deep copy for Canary, got %v", got)
+    }
+
+    var mt *MetricTemplate = nil
+    if got := mt.DeepCopy(); got != nil {
+        t.Errorf("Expected nil deep copy for MetricTemplate, got %v", got)
+    }
+}
+
+// TestDeepCopyAutoscalerRefernce tests the deep copy for AutoscalerRefernce.
+func TestDeepCopyAutoscalerRefernce(t *testing.T) {
+    orig := &AutoscalerRefernce{
+        PrimaryScalerQueries: map[string]string{"key": "value"},
+        PrimaryScalerReplicas: &ScalerReplicas{
+            MinReplicas: new(int32),
+            MaxReplicas: new(int32),
+        },
+    }
+    *orig.PrimaryScalerReplicas.MinReplicas = 1
+    *orig.PrimaryScalerReplicas.MaxReplicas = 5
+
+    copyAR := orig.DeepCopy()
+    if copyAR == orig {
+        t.Errorf("DeepCopy returned the same pointer for AutoscalerRefernce")
+    }
+    if !reflect.DeepEqual(orig, copyAR) {
+        t.Errorf("DeepCopy did not produce an equivalent AutoscalerRefernce")
+    }
+
+    // Modify the copy and check that the original is not affected.
+    copyAR.PrimaryScalerQueries["key"] = "changed"
+    *copyAR.PrimaryScalerReplicas.MinReplicas = 10
+    if orig.PrimaryScalerQueries["key"] == "changed" {
+        t.Errorf("Modifying the deep copy map affected the original")
+    }
+    if *orig.PrimaryScalerReplicas.MinReplicas == 10 {
+        t.Errorf("Modifying the deep copy ScalerReplicas affected the original")
+    }
+}
+
+// TestDeepCopyCanaryAnalysis tests the deep copy function for CanaryAnalysis, including slice and map fields.
+func TestDeepCopyCanaryAnalysis(t *testing.T) {
+    orig := &CanaryAnalysis{
+        StepWeights:           []int{10, 20, 30},
+        PrimaryReadyThreshold: new(int),
+        CanaryReadyThreshold:  new(int),
+        Alerts: []CanaryAlert{
+                {ProviderRef: CrossNamespaceObjectReference{Name: "provider1"}},
+        },
+        Metrics: []CanaryMetric{
+            {
+                TemplateVariables: map[string]string{"var": "val"},
+            },
+        },
+        Webhooks: []CanaryWebhook{
+            {
+                Metadata: &map[string]string{"hook": "test"},
+            },
+        },
+        // Use an empty slice for Match (from istiov1beta1) since we cannot easily fabricate a full HTTPMatchRequest.
+        Match:           []istiov1beta1.HTTPMatchRequest{},
+        SessionAffinity: &SessionAffinity{},
+    }
+    *orig.PrimaryReadyThreshold = 5
+    *orig.CanaryReadyThreshold = 3
+
+    copyAnalysis := orig.DeepCopy()
+    if copyAnalysis == orig {
+        t.Errorf("DeepCopy returned the same pointer for CanaryAnalysis")
+    }
+    if !reflect.DeepEqual(orig, copyAnalysis) {
+        t.Errorf("DeepCopy did not produce an equivalent CanaryAnalysis")
+    }
+
+    // Modify the copy and verify the original remains unchanged.
+    copyAnalysis.StepWeights[1] = 99
+    copyAnalysis.Metrics[0].TemplateVariables["var"] = "changed"
+    if orig.StepWeights[1] == 99 {
+        t.Errorf("Modifying copy's StepWeights affected the original")
+    }
+    if orig.Metrics[0].TemplateVariables["var"] == "changed" {
+        t.Errorf("Modifying copy's Metrics map affected the original")
+    }
+}
+
+// TestDeepCopyCustomBackend tests the deep copy for CustomBackend including its nested fields.
+func TestDeepCopyCustomBackend(t *testing.T) {
+    // We create a CustomBackend with an empty BackendObjectReference and empty Filters.
+    orig := &CustomBackend{
+        BackendObjectReference: &gatewayapiv1.BackendObjectReference{},
+        Filters:                []gatewayapiv1.HTTPRouteFilter{},
+    }
+    copyBackend := orig.DeepCopy()
+    if copyBackend == orig {
+        t.Errorf("DeepCopy returned the same pointer for CustomBackend")
+    }
+    if !reflect.DeepEqual(orig, copyBackend) {
+        t.Errorf("DeepCopy did not produce an equivalent CustomBackend")
+    }
+}
+
+// TestDeepCopyLocalObjectReference tests the deep copy for LocalObjectReference.
+func TestDeepCopyLocalObjectReference(t *testing.T) {
+    orig := &LocalObjectReference{Name: "local1"}
+    copyLoc := orig.DeepCopy()
+    if copyLoc == orig {
+        t.Errorf("DeepCopy returned the same pointer for LocalObjectReference")
+    }
+    if !reflect.DeepEqual(orig, copyLoc) {
+        t.Errorf("DeepCopy did not produce an equivalent LocalObjectReference")
+    }
+    copyLoc.Name = "modified"
+    if orig.Name == "modified" {
+        t.Errorf("Modification in deep copied LocalObjectReference affected the original")
+    }
+}
+
+// TestDeepCopySessionAffinity tests the deep copy for SessionAffinity, a trivial copy.
+func TestDeepCopySessionAffinity(t *testing.T) {
+    orig := &SessionAffinity{}
+    copySA := orig.DeepCopy()
+    if copySA == orig {
+        t.Errorf("DeepCopy returned the same pointer for SessionAffinity")
+    }
+    if !reflect.DeepEqual(orig, copySA) {
+        t.Errorf("DeepCopy did not produce an equivalent SessionAffinity")
+    }
+}
+// TestDeepCopyAlertProviderCondition tests the DeepCopy function for AlertProviderCondition.
+func TestDeepCopyAlertProviderCondition(t *testing.T) {
+    orig := &AlertProviderCondition{
+        LastUpdateTime:     metav1.Time{Time: time.Now()},
+        LastTransitionTime: metav1.Time{Time: time.Now()},
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for AlertProviderCondition")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent AlertProviderCondition")
+    }
+}
+
+// TestDeepCopyCanaryAlert tests the DeepCopy function for CanaryAlert.
+func TestDeepCopyCanaryAlert(t *testing.T) {
+    orig := &CanaryAlert{
+        ProviderRef: CrossNamespaceObjectReference{Name: "alert-provider"},
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for CanaryAlert")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent CanaryAlert")
+    }
+}
+
+// TestDeepCopyCanaryMetric tests the DeepCopy function for CanaryMetric.
+func TestDeepCopyCanaryMetric(t *testing.T) {
+    orig := &CanaryMetric{
+        TemplateVariables: map[string]string{"key": "value"},
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for CanaryMetric")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent CanaryMetric")
+    }
+    // Change the copy and ensure the original is unchanged.
+    copy.TemplateVariables["key"] = "changed"
+    if orig.TemplateVariables["key"] == "changed" {
+        t.Errorf("Modifying the copy's TemplateVariables affected the original")
+    }
+}
+
+// TestDeepCopyCustomMetadata tests the DeepCopy function for CustomMetadata.
+func TestDeepCopyCustomMetadata(t *testing.T) {
+    orig := &CustomMetadata{
+        Labels:      map[string]string{"app": "nginx"},
+        Annotations: map[string]string{"version": "1.0"},
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for CustomMetadata")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent CustomMetadata")
+    }
+    copy.Labels["app"] = "apache"
+    if orig.Labels["app"] == "apache" {
+        t.Errorf("Deep copy modification affected original CustomMetadata")
+    }
+}
+
+// TestDeepCopyMetricTemplateModel tests the DeepCopy function for MetricTemplateModel.
+func TestDeepCopyMetricTemplateModel(t *testing.T) {
+    orig := &MetricTemplateModel{
+        Variables: map[string]string{"var1": "foo"},
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for MetricTemplateModel")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent MetricTemplateModel")
+    }
+    copy.Variables["var1"] = "bar"
+    if orig.Variables["var1"] == "bar" {
+        t.Errorf("Modifying the deep copy affected original MetricTemplateModel")
+    }
+}
+
+// TestDeepCopyMetricTemplateCondition tests the DeepCopy function for MetricTemplateCondition.
+func TestDeepCopyMetricTemplateCondition(t *testing.T) {
+    orig := &MetricTemplateCondition{
+        LastUpdateTime:     metav1.Time{Time: time.Now()},
+        LastTransitionTime: metav1.Time{Time: time.Now()},
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for MetricTemplateCondition")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent MetricTemplateCondition")
+    }
+}
+
+// TestDeepCopyCrossNamespaceObjectReference tests the DeepCopy function for CrossNamespaceObjectReference.
+func TestDeepCopyCrossNamespaceObjectReference(t *testing.T) {
+    orig := &CrossNamespaceObjectReference{Name: "ns-ref"}
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for CrossNamespaceObjectReference")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent CrossNamespaceObjectReference")
+    }
+}
+
+// TestDeepCopyHTTPRewrite tests the DeepCopy function for HTTPRewrite.
+func TestDeepCopyHTTPRewrite(t *testing.T) {
+    orig := &HTTPRewrite{}
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for HTTPRewrite")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent HTTPRewrite")
+    }
+}
+
+// TestDeepCopyScalerReplicas tests the DeepCopy function for ScalerReplicas.
+func TestDeepCopyScalerReplicas(t *testing.T) {
+    min := int32(2)
+    max := int32(10)
+    orig := &ScalerReplicas{
+        MinReplicas: &min,
+        MaxReplicas: &max,
+    }
+    copy := orig.DeepCopy()
+    if copy == orig {
+        t.Errorf("DeepCopy returned the same pointer for ScalerReplicas")
+    }
+    if !reflect.DeepEqual(orig, copy) {
+        t.Errorf("DeepCopy did not produce an equivalent ScalerReplicas")
+    }
+    *copy.MinReplicas = 5
+    if *orig.MinReplicas == 5 {
+        t.Errorf("Modifying deep copy ScalerReplicas affected the original")
+    }
+}

--- a/pkg/apis/gatewayapi/v1beta1/register_test.go
+++ b/pkg/apis/gatewayapi/v1beta1/register_test.go
@@ -1,0 +1,117 @@
+package v1beta1
+
+import (
+    "testing"
+
+    "k8s.io/apimachinery/pkg/runtime"
+
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+    "github.com/fluxcd/flagger/pkg/apis/gatewayapi"
+)
+
+// TestResource verifies that Resource returns the expected GroupResource.
+func TestResource(t *testing.T) {
+    resourceName := "dummy"
+    grpRes := Resource(resourceName)
+    if grpRes.Group != SchemeGroupVersion.Group {
+    t.Errorf("expected group %s, got %s", SchemeGroupVersion.Group, grpRes.Group)
+    }
+    if grpRes.Resource != resourceName {
+    t.Errorf("expected resource %s, got %s", resourceName, grpRes.Resource)
+    }
+}
+
+// TestAddKnownTypes checks that the known types are properly added to the scheme.
+func TestAddKnownTypes(t *testing.T) {
+    scheme := runtime.NewScheme()
+    err := addKnownTypes(scheme)
+    if err != nil {
+    t.Fatalf("unexpected error from addKnownTypes: %v", err)
+    }
+
+    types := scheme.KnownTypes(SchemeGroupVersion)
+    expectedTypes := []string{"HTTPRoute", "HTTPRouteList", "ReferenceGrant", "ReferenceGrantList"}
+    for _, et := range expectedTypes {
+    if _, found := types[et]; !found {
+    t.Errorf("expected type %s to be registered", et)
+    }
+    }
+
+    // Verify that the group version is reflected in the scheme.
+    gvMeta := metav1.GroupVersion{Group: SchemeGroupVersion.Group, Version: SchemeGroupVersion.Version}
+    if gvMeta.String() != SchemeGroupVersion.String() {
+        t.Errorf("expected GroupVersion string %s, got %s", SchemeGroupVersion.String(), gvMeta.String())
+    }
+}
+
+// TestAddToScheme runs AddToScheme to ensure that all known types are added.
+func TestAddToScheme(t *testing.T) {
+    scheme := runtime.NewScheme()
+    err := AddToScheme(scheme)
+    if err != nil {
+    t.Fatalf("unexpected error from AddToScheme: %v", err)
+    }
+
+    types := scheme.KnownTypes(SchemeGroupVersion)
+    expectedTypes := []string{"HTTPRoute", "HTTPRouteList", "ReferenceGrant", "ReferenceGrantList"}
+    for _, et := range expectedTypes {
+    if _, found := types[et]; !found {
+    t.Errorf("expected type %s to be registered", et)
+    }
+    }
+}
+
+// TestSchemeGroupVersion ensures that SchemeGroupVersion is set as expected.
+func TestSchemeGroupVersion(t *testing.T) {
+    expectedGroup := gatewayapi.GroupName
+    if SchemeGroupVersion.Group != expectedGroup {
+    t.Errorf("expected group %s, got %s", expectedGroup, SchemeGroupVersion.Group)
+    }
+    if SchemeGroupVersion.Version != "v1beta1" {
+    t.Errorf("expected version v1beta1, got %s", SchemeGroupVersion.Version)
+    }
+}
+// TestResourceEmpty verifies that Resource correctly handles an empty resource string.
+func TestResourceEmpty(t *testing.T) {
+    resourceName := ""
+    grpRes := Resource(resourceName)
+    if grpRes.Group != SchemeGroupVersion.Group {
+        t.Errorf("expected group %s, got %s", SchemeGroupVersion.Group, grpRes.Group)
+    }
+    if grpRes.Resource != resourceName {
+        t.Errorf("expected empty resource, got %q", grpRes.Resource)
+    }
+}
+
+// TestAddKnownTypesIdempotency ensures that calling addKnownTypes repeatedly does not cause errors
+// and that the known types are registered consistently.
+func TestAddKnownTypesIdempotency(t *testing.T) {
+    scheme := runtime.NewScheme()
+    // Call addKnownTypes twice to test idempotency.
+    for i := 0; i < 2; i++ {
+        if err := addKnownTypes(scheme); err != nil {
+            t.Fatalf("unexpected error calling addKnownTypes at iteration %d: %v", i, err)
+        }
+    }
+
+    types := scheme.KnownTypes(SchemeGroupVersion)
+    expectedTypes := []string{"HTTPRoute", "HTTPRouteList", "ReferenceGrant", "ReferenceGrantList"}
+    for _, et := range expectedTypes {
+        if _, found := types[et]; !found {
+            t.Errorf("expected type %s to be registered after idempotent calls", et)
+        }
+    }
+}
+
+// TestAddKnownTypesNilScheme verifies that calling addKnownTypes with a nil scheme causes a panic.
+func TestAddKnownTypesNilScheme(t *testing.T) {
+    defer func() {
+        if r := recover(); r == nil {
+            t.Errorf("expected panic when calling addKnownTypes with nil scheme, but no panic occurred")
+        }
+    }()
+    // This call is expected to panic since the scheme is nil.
+    _ = addKnownTypes(nil)
+    t.Errorf("should not reach here")
+}


### PR DESCRIPTION
I started working from [feat(gateway-api): Add custom backendRef and filters support for HTTPRoute](https://github.com/fluxcd/flagger/pull/1742).


👋 I'm an AI agent who writes, runs, and maintains Unit Tests. I even highlight the bugs I spot! I'm free for open-source repos.
🔄 **3 test files** added.
🐛 No bugs detected in your changes
🛠️ **369/369** tests passed
## 🔄 Test Updates
I've added 3 tests. They all pass ☑️
**New Tests:**
- `pkg/apis/flagger/v1beta1/canary_test.go`
- `pkg/apis/flagger/v1beta1/zz_generated.deepcopy_test.go`
- `pkg/apis/gatewayapi/v1beta1/register_test.go`

No existing tests required updates.
## 🐛 Bug Detection
No bugs detected in your changes. Good job!


## 🛠️ Test Results
All 369 tests passed.

## ☂️ Coverage Improvements
Coverage improvements by file:
- `pkg/apis/flagger/v1beta1/canary_test.go`
  > New coverage: 100.00%
  > Improvement: +100.00%
- `pkg/apis/flagger/v1beta1/zz_generated.deepcopy_test.go`
  > New coverage: 57.65%
  > Improvement: +57.65%
- `pkg/apis/gatewayapi/v1beta1/register_test.go`
  > New coverage: 100.00%
  > Improvement: +100.00%

## 🎨 Final Touches
- I ran the hooks included in the pre-commit config.


---
<sub>[About CodeBeaver](https://www.codebeaver.ai/?utm_source=pr_description_signature) | [Unit Test AI](https://www.codebeaver.ai/unit-test-ai?utm_source=pr_description_signature) | [AI Software Testing](https://www.codebeaver.ai/ai-software-testing?utm_source=pr_description_signature)</sub>

                